### PR TITLE
Don't use "use lib" in tests.

### DIFF
--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl6
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/02-structure.t
+++ b/t/02-structure.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl6
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/03-unicode.t
+++ b/t/03-unicode.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl6
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/04-roundtrip.t
+++ b/t/04-roundtrip.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl6
 use Test;
-use lib 'lib';
 use JSON::Fast;
 
 my @s =

--- a/t/07-datetime.t
+++ b/t/07-datetime.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl6
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/09-race.t
+++ b/t/09-race.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl6
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/10-multidocument.t
+++ b/t/10-multidocument.t
@@ -1,5 +1,4 @@
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/11-enum.t
+++ b/t/11-enum.t
@@ -1,5 +1,4 @@
 use v6;
-use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/xt/meta.t
+++ b/xt/meta.t
@@ -1,6 +1,5 @@
 use v6;
 
-use lib 'lib';
 use Test;
 use Test::META;
 


### PR DESCRIPTION
Causes double precomp on install and (as of 2023) installation failures on windows

Closes #91